### PR TITLE
Put the missing comma in README.md lazy.nvim entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ require("error-lens").setup(client, {
     event = "BufRead",
     dependencies = {
         "nvim-telescope/telescope.nvim"
-    }
+    },
     opts = {
         -- your options go here
     },


### PR DESCRIPTION
There is a missing comma in the lazy.nvim entry. It would be easier for people who copy paste the snippet with the "opts{} "part.