### PR TITLE
Fix: Prevent out-of-range line error in set_highlight function

### DIFF
--- a/lua/error-lens/config.lua
+++ b/lua/error-lens/config.lua
@@ -10,99 +10,92 @@ local vim_info = "DiagnosticInfo"
 local vim_hint = "DiagnosticHint"
 
 local default_options = {
-	enabled = true,
-	auto_adjust = {
-		enable = false,
-		fallback_bg_color = nil,
-		step = 7,
-		total = 30,
-	},
-	prefix = 4,
-	colors = {
-		error_fg = "#FF6363",
-		error_bg = "#4B252C",
-		warn_fg = "#FA973A",
-		warn_bg = "#403733",
-		info_fg = "#387EFF",
-		info_bg = "#20355A",
-		hint_fg = "#16C53B",
-		hint_bg = "#254435",
-	},
+  enabled = true,
+  auto_adjust = {
+    enable = false,
+    fallback_bg_color = nil,
+    step = 7,
+    total = 30,
+  },
+  prefix = 4,
+  colors = {
+    error_fg = "#FF6363",
+    error_bg = "#4B252C",
+    warn_fg = "#FA973A",
+    warn_bg = "#403733",
+    info_fg = "#387EFF",
+    info_bg = "#20355A",
+    -- hint_fg = "#16C53B",
+    hint_fg = "#139A44",
+    hint_bg = "#254435",
+  },
 }
 
 function M.setup(options)
-	-- Merge user options with default options
-	M.options = vim.tbl_deep_extend("force", {}, default_options, options or {})
+  -- Merge user options with default options
+  M.options = vim.tbl_deep_extend("force", {}, default_options, options or {})
 
-	if M.options.auto_adjust.enable then
-		if M.options.auto_adjust.fallback_bg_color == nil then
-			error("Error: 'fallback_bg_color' is mandatory when 'auto_adjust' is enabled.")
-		else
-			local step = M.options.auto_adjust.step
-			local total = M.options.auto_adjust.total
+  if M.options.auto_adjust.enable then
+    if M.options.auto_adjust.fallback_bg_color == nil then
+      error("Error: 'fallback_bg_color' is mandatory when 'auto_adjust' is enabled.")
+    else
+      local step = M.options.auto_adjust.step
+      local total = M.options.auto_adjust.total
 
-			local theme_color = utils.get_default_theme_bg_color()
+      local theme_color = utils.get_default_theme_bg_color()
 
-			local background_color
-			if theme_color ~= nil then
-				background_color = theme_color
-			else
-				background_color = M.options.auto_adjust.fallback_bg_color
-			end
+      local background_color
+      if theme_color ~= nil then
+        background_color = theme_color
+      else
+        background_color = M.options.auto_adjust.fallback_bg_color
+      end
 
-			-- Get adjusted colors based on the fallback_bg_color color
-			M.options.colors.error_fg, M.options.colors.error_bg =
-				utils.get_default_diagnostic_colors(background_color, vim_error, step, total)
-			M.options.colors.warn_fg, M.options.colors.warn_bg =
-				utils.get_default_diagnostic_colors(background_color, vim_warn, step, total)
-			M.options.colors.info_fg, M.options.colors.info_bg =
-				utils.get_default_diagnostic_colors(background_color, vim_info, step, total)
-			M.options.colors.hint_fg, M.options.colors.hint_bg =
-				utils.get_default_diagnostic_colors(background_color, vim_hint, step, total)
-		end
-	end
+      -- Get adjusted colors based on the fallback_bg_color color
+      M.options.colors.error_fg, M.options.colors.error_bg =
+        utils.get_default_diagnostic_colors(background_color, vim_error, step, total)
+      M.options.colors.warn_fg, M.options.colors.warn_bg =
+        utils.get_default_diagnostic_colors(background_color, vim_warn, step, total)
+      M.options.colors.info_fg, M.options.colors.info_bg =
+        utils.get_default_diagnostic_colors(background_color, vim_info, step, total)
+      M.options.colors.hint_fg, M.options.colors.hint_bg =
+        utils.get_default_diagnostic_colors(background_color, vim_hint, step, total)
+    end
+  end
 
-	-- Set highlights using the M.options.colors values
-	vim.api.nvim_set_hl(M.namespace, "ErrorLensErrorText", { fg = nil, bg = M.options.colors.error_bg })
-	vim.api.nvim_set_hl(
-		M.namespace,
-		"ErrorLensErrorBg",
-		{ fg = M.options.colors.error_fg, bg = M.options.colors.error_bg }
-	)
+  -- Set highlights using the M.options.colors values
+  vim.api.nvim_set_hl(M.namespace, "ErrorLensErrorText", { fg = nil, bg = M.options.colors.error_bg })
+  vim.api.nvim_set_hl(
+    M.namespace,
+    "ErrorLensErrorBg",
+    { fg = M.options.colors.error_fg, bg = M.options.colors.error_bg }
+  )
 
-	vim.api.nvim_set_hl(M.namespace, "ErrorLensWarnText", { fg = nil, bg = M.options.colors.warn_bg })
-	vim.api.nvim_set_hl(
-		M.namespace,
-		"ErrorLensWarnBg",
-		{ fg = M.options.colors.warn_fg, bg = M.options.colors.warn_bg }
-	)
+  vim.api.nvim_set_hl(M.namespace, "ErrorLensWarnText", { fg = nil, bg = M.options.colors.warn_bg, italic = true })
+  vim.api.nvim_set_hl(M.namespace, "ErrorLensWarnBg", { fg = M.options.colors.warn_fg, bg = M.options.colors.warn_bg })
 
-	vim.api.nvim_set_hl(M.namespace, "ErrorLensInfoText", { fg = nil, bg = M.options.colors.info_bg })
-	vim.api.nvim_set_hl(
-		M.namespace,
-		"ErrorLensInfoBg",
-		{ fg = M.options.colors.info_fg, bg = M.options.colors.info_bg }
-	)
+  vim.api.nvim_set_hl(M.namespace, "ErrorLensInfoText", { fg = nil, bg = M.options.colors.info_bg, italic = true })
+  vim.api.nvim_set_hl(M.namespace, "ErrorLensInfoBg", { fg = M.options.colors.info_fg, bg = M.options.colors.info_bg })
 
-	vim.api.nvim_set_hl(M.namespace, "ErrorLensHintText", { fg = nil, bg = M.options.colors.hint_bg })
-	vim.api.nvim_set_hl(
-		M.namespace,
-		"ErrorLensHintBg",
-		{ fg = M.options.colors.hint_fg, bg = M.options.colors.hint_bg }
-	)
+  vim.api.nvim_set_hl(
+    M.namespace,
+    "ErrorLensHintText",
+    { fg = "#B0B0B0", bg = M.options.colors.hint_bg, italic = true }
+  )
+  vim.api.nvim_set_hl(M.namespace, "ErrorLensHintBg", { fg = M.options.colors.hint_fg, bg = M.options.colors.hint_bg })
 
-	vim.api.nvim_set_hl_ns(M.namespace)
+  vim.api.nvim_set_hl_ns(M.namespace)
 
-	-- Save the user's original virtual_text setting
-	M.user_virtual_text = vim.diagnostic.config().virtual_text
+  -- Save the user's original virtual_text setting
+  M.user_virtual_text = vim.diagnostic.config().virtual_text
 
-	utils.set_virtual_text(false)
+  utils.set_virtual_text(false)
 
-	if M.options.enabled then
-		vim.diagnostic.config({ error_lens = true })
-	else
-		vim.diagnostic.config({ error_lens = false })
-	end
+  if M.options.enabled then
+    vim.diagnostic.config({ error_lens = true })
+  else
+    vim.diagnostic.config({ error_lens = false })
+  end
 end
 
 return M

--- a/lua/error-lens/highlight.lua
+++ b/lua/error-lens/highlight.lua
@@ -1,7 +1,18 @@
 local config = require("error-lens.config")
 
 local function set_highlight(buf, diagnostic, fg, bg, first)
+	-- Get the number of lines in the buffer
+	local line_count = vim.api.nvim_buf_line_count(buf)
+
+	-- Ensure diagnostic.lnum is within the buffer's range
+	if diagnostic.lnum < 0 or diagnostic.lnum >= line_count then
+		return -- Skip setting the highlight if line is out of range
+	end
+
+	-- Add highlight
 	vim.api.nvim_buf_add_highlight(buf, config.namespace, fg, diagnostic.lnum, 0, -1)
+
+	-- Add extmark
 	vim.api.nvim_buf_set_extmark(buf, config.namespace, diagnostic.lnum, 0, {
 		hl_mode = "combine",
 		hl_eol = true,
@@ -19,9 +30,6 @@ local function clear_highlights(buf)
 end
 
 local function update_highlights(buf, diagnostics)
-	if vim.bo[buf].filetype == "neo-tree" then
-		return -- Skip neo-tree buffers
-	end
 	clear_highlights(buf)
 	local first = true
 	local old_lnum = -1

--- a/lua/error-lens/highlight.lua
+++ b/lua/error-lens/highlight.lua
@@ -2,7 +2,7 @@ local config = require("error-lens.config")
 
 local function set_highlight(buf, diagnostic, fg, bg, first)
   -- Skip highlighting for inactive-code diagnostics
-  if diagnostic.source == "rust-analyzer" and diagnostic.message:find("inactive code") then
+  if diagnostic.message:match("code is inactive") then
     return
   end
 

--- a/lua/error-lens/highlight.lua
+++ b/lua/error-lens/highlight.lua
@@ -1,50 +1,49 @@
 local config = require("error-lens.config")
 
 local function set_highlight(buf, diagnostic, fg, bg, first)
-
-    vim.api.nvim_buf_add_highlight(buf, config.namespace, fg, diagnostic.lnum, 0, -1)
-    vim.api.nvim_buf_set_extmark(buf, config.namespace, diagnostic.lnum, 0, {
-        hl_mode = "combine",
-        hl_eol = true,
-        hl_group = bg,
-        virt_text = {
-            { (first and string.rep(" ", 3) or "") }, -- more spacing first time
-            { string.rep(" ", 2) .. diagnostic.message .. string.rep(" ", 2), bg },
-        },
-        priority = 4 - diagnostic.severity,
-    })
+	vim.api.nvim_buf_add_highlight(buf, config.namespace, fg, diagnostic.lnum, 0, -1)
+	vim.api.nvim_buf_set_extmark(buf, config.namespace, diagnostic.lnum, 0, {
+		hl_mode = "combine",
+		hl_eol = true,
+		hl_group = bg,
+		virt_text = {
+			{ (first and string.rep(" ", 3) or "") }, -- more spacing first time
+			{ string.rep(" ", 2) .. diagnostic.message .. string.rep(" ", 2), bg },
+		},
+		priority = 4 - diagnostic.severity,
+	})
 end
 
 local function clear_highlights(buf)
-    vim.api.nvim_buf_clear_namespace(buf, config.namespace, 0, -1)
+	vim.api.nvim_buf_clear_namespace(buf, config.namespace, 0, -1)
 end
 
 local function update_highlights(buf, diagnostics)
-  if vim.bo[buf].filetype === "neo-tree" then
-    return -- Skip neo-tree buffers
-  end
-    clear_highlights(buf)
-    local first = true
-    local old_lnum=-1
-    for _, diagnostic in ipairs(diagnostics) do
-        if old_lnum ~= diagnostic.lnum then
-            first = true
-            old_lnum = diagnostic.lnum
-        end
-        if diagnostic.severity == vim.diagnostic.severity.ERROR then
-            set_highlight(buf, diagnostic, "ErrorLensErrorText", "ErrorLensErrorBg", first)
-        elseif diagnostic.severity == vim.diagnostic.severity.WARN then
-            set_highlight(buf, diagnostic, "ErrorLensWarnText", "ErrorLensWarnBg", first)
-        elseif diagnostic.severity == vim.diagnostic.severity.INFO then
-            set_highlight(buf, diagnostic, "ErrorLensInfoText", "ErrorLensInfoBg", first)
-        elseif diagnostic.severity == vim.diagnostic.severity.HINT then
-            set_highlight(buf, diagnostic, "ErrorLensHintText", "ErrorLensHintBg", first)
-        end
-        first = false
-    end
+	if vim.bo[buf].filetype == "neo-tree" then
+		return -- Skip neo-tree buffers
+	end
+	clear_highlights(buf)
+	local first = true
+	local old_lnum = -1
+	for _, diagnostic in ipairs(diagnostics) do
+		if old_lnum ~= diagnostic.lnum then
+			first = true
+			old_lnum = diagnostic.lnum
+		end
+		if diagnostic.severity == vim.diagnostic.severity.ERROR then
+			set_highlight(buf, diagnostic, "ErrorLensErrorText", "ErrorLensErrorBg", first)
+		elseif diagnostic.severity == vim.diagnostic.severity.WARN then
+			set_highlight(buf, diagnostic, "ErrorLensWarnText", "ErrorLensWarnBg", first)
+		elseif diagnostic.severity == vim.diagnostic.severity.INFO then
+			set_highlight(buf, diagnostic, "ErrorLensInfoText", "ErrorLensInfoBg", first)
+		elseif diagnostic.severity == vim.diagnostic.severity.HINT then
+			set_highlight(buf, diagnostic, "ErrorLensHintText", "ErrorLensHintBg", first)
+		end
+		first = false
+	end
 end
 
 return {
-    update_highlights = update_highlights,
-    clear_highlights = clear_highlights,
+	update_highlights = update_highlights,
+	clear_highlights = clear_highlights,
 }

--- a/lua/error-lens/highlight.lua
+++ b/lua/error-lens/highlight.lua
@@ -1,57 +1,62 @@
 local config = require("error-lens.config")
 
 local function set_highlight(buf, diagnostic, fg, bg, first)
-	-- Get the number of lines in the buffer
-	local line_count = vim.api.nvim_buf_line_count(buf)
+  -- Skip highlighting for inactive-code diagnostics
+  if diagnostic.source == "rust-analyzer" and diagnostic.message:find("inactive code") then
+    return
+  end
 
-	-- Ensure diagnostic.lnum is within the buffer's range
-	if diagnostic.lnum < 0 or diagnostic.lnum >= line_count then
-		return -- Skip setting the highlight if line is out of range
-	end
+  -- Get the number of lines in the buffer
+  local line_count = vim.api.nvim_buf_line_count(buf)
 
-	-- Add highlight
-	vim.api.nvim_buf_add_highlight(buf, config.namespace, fg, diagnostic.lnum, 0, -1)
+  -- Ensure diagnostic.lnum is within the buffer's range
+  if diagnostic.lnum < 0 or diagnostic.lnum >= line_count then
+    return -- Skip setting the highlight if line is out of range
+  end
 
-	-- Add extmark
-	vim.api.nvim_buf_set_extmark(buf, config.namespace, diagnostic.lnum, 0, {
-		hl_mode = "combine",
-		hl_eol = true,
-		hl_group = bg,
-		virt_text = {
-			{ (first and string.rep(" ", 3) or "") }, -- more spacing first time
-			{ string.rep(" ", 2) .. diagnostic.message .. string.rep(" ", 2), bg },
-		},
-		priority = 4 - diagnostic.severity,
-	})
+  -- Add highlight
+  vim.api.nvim_buf_add_highlight(buf, config.namespace, fg, diagnostic.lnum, 0, -1)
+
+  -- Add extmark
+  vim.api.nvim_buf_set_extmark(buf, config.namespace, diagnostic.lnum, 0, {
+    hl_mode = "combine",
+    hl_eol = true,
+    hl_group = bg,
+    virt_text = {
+      { (first and string.rep(" ", 3) or "") }, -- more spacing first time
+      { string.rep(" ", 2) .. diagnostic.message .. string.rep(" ", 2), bg },
+    },
+    priority = 4 - diagnostic.severity,
+  })
 end
 
 local function clear_highlights(buf)
-	vim.api.nvim_buf_clear_namespace(buf, config.namespace, 0, -1)
+  vim.api.nvim_buf_clear_namespace(buf, config.namespace, 0, -1)
 end
 
 local function update_highlights(buf, diagnostics)
-	clear_highlights(buf)
-	local first = true
-	local old_lnum = -1
-	for _, diagnostic in ipairs(diagnostics) do
-		if old_lnum ~= diagnostic.lnum then
-			first = true
-			old_lnum = diagnostic.lnum
-		end
-		if diagnostic.severity == vim.diagnostic.severity.ERROR then
-			set_highlight(buf, diagnostic, "ErrorLensErrorText", "ErrorLensErrorBg", first)
-		elseif diagnostic.severity == vim.diagnostic.severity.WARN then
-			set_highlight(buf, diagnostic, "ErrorLensWarnText", "ErrorLensWarnBg", first)
-		elseif diagnostic.severity == vim.diagnostic.severity.INFO then
-			set_highlight(buf, diagnostic, "ErrorLensInfoText", "ErrorLensInfoBg", first)
-		elseif diagnostic.severity == vim.diagnostic.severity.HINT then
-			set_highlight(buf, diagnostic, "ErrorLensHintText", "ErrorLensHintBg", first)
-		end
-		first = false
-	end
+  clear_highlights(buf)
+  local first = true
+  local old_lnum = -1
+  for _, diagnostic in ipairs(diagnostics) do
+    if old_lnum ~= diagnostic.lnum then
+      first = true
+      old_lnum = diagnostic.lnum
+    end
+    if diagnostic.severity == vim.diagnostic.severity.ERROR then
+      set_highlight(buf, diagnostic, "ErrorLensErrorText", "ErrorLensErrorBg", first)
+    elseif diagnostic.severity == vim.diagnostic.severity.WARN then
+      set_highlight(buf, diagnostic, "ErrorLensWarnText", "ErrorLensWarnBg", first)
+    elseif diagnostic.severity == vim.diagnostic.severity.INFO then
+      set_highlight(buf, diagnostic, "ErrorLensInfoText", "ErrorLensInfoBg", first)
+    elseif diagnostic.severity == vim.diagnostic.severity.HINT then
+      set_highlight(buf, diagnostic, "ErrorLensHintText", "ErrorLensHintBg", first)
+    end
+    first = false
+  end
 end
 
 return {
-	update_highlights = update_highlights,
-	clear_highlights = clear_highlights,
+  update_highlights = update_highlights,
+  clear_highlights = clear_highlights,
 }

--- a/lua/error-lens/highlight.lua
+++ b/lua/error-lens/highlight.lua
@@ -1,6 +1,7 @@
 local config = require("error-lens.config")
 
 local function set_highlight(buf, diagnostic, fg, bg, first)
+
     vim.api.nvim_buf_add_highlight(buf, config.namespace, fg, diagnostic.lnum, 0, -1)
     vim.api.nvim_buf_set_extmark(buf, config.namespace, diagnostic.lnum, 0, {
         hl_mode = "combine",
@@ -19,6 +20,9 @@ local function clear_highlights(buf)
 end
 
 local function update_highlights(buf, diagnostics)
+  if vim.bo[buf].filetype === "neo-tree" then
+    return -- Skip neo-tree buffers
+  end
     clear_highlights(buf)
     local first = true
     local old_lnum=-1

--- a/lua/error-lens/utils.lua
+++ b/lua/error-lens/utils.lua
@@ -1,56 +1,57 @@
 local function hexToRGB(hex)
-	hex = hex:gsub("#", "")
-	return tonumber("0x" .. hex:sub(1, 2)), tonumber("0x" .. hex:sub(3, 4)), tonumber("0x" .. hex:sub(5, 6))
+  hex = hex:gsub("#", "")
+  return tonumber("0x" .. hex:sub(1, 2)), tonumber("0x" .. hex:sub(3, 4)), tonumber("0x" .. hex:sub(5, 6))
 end
 
 function RGBToHex(r, g, b)
-	return string.format("#%02X%02X%02X", r, g, b)
+  return string.format("#%02X%02X%02X", r, g, b)
 end
 
 local function color_bend(hex1, hex2, step, total)
-	local r1, g1, b1 = hexToRGB(hex1)
-	local r2, g2, b2 = hexToRGB(hex2)
-	local t = step / total
+  local r1, g1, b1 = hexToRGB(hex1)
+  local r2, g2, b2 = hexToRGB(hex2)
+  local t = step / total
 
-	local r = r1 + (r2 - r1) * t
-	local g = g1 + (g2 - g1) * t
-	local b = b1 + (b2 - b1) * t
+  local r = r1 + (r2 - r1) * t
+  local g = g1 + (g2 - g1) * t
+  local b = b1 + (b2 - b1) * t
 
-	return RGBToHex(math.floor(r), math.floor(g), math.floor(b))
+  return RGBToHex(math.floor(r), math.floor(g), math.floor(b))
 end
 
 local function get_default_diagnostic_colors(fallback_bg_color, hi_group, step, total)
-	local color = vim.api.nvim_get_hl_by_name(hi_group, true)
-	local fg = string.format("#%06x", color.foreground)
-	local bg
+  local color = vim.api.nvim_get_hl_by_name(hi_group, true)
+  local fg = string.format("#%06x", color.foreground)
+  local bg
 
-	if color.background ~= nil then
-		bg = string.format("#%06x", color.background)
-	else
-		bg = color_bend(fallback_bg_color, fg, step, total)
-	end
+  if color.background ~= nil then
+    bg = string.format("#%06x", color.background)
+  else
+    bg = color_bend(fallback_bg_color, fg, step, total)
+  end
 
-	return fg, bg
+  return fg, bg
 end
 
 local function get_default_theme_bg_color()
-	local theme_color = vim.api.nvim_get_hl_by_name('Normal',true).background
+  local theme_color = vim.api.nvim_get_hl_by_name("Normal", true).background
 
-	if theme_color ~= nil then
-		return string.format('#%06x', theme_color)
-	else
-		return nil
-	end
+  if theme_color ~= nil then
+    return string.format("#%06x", theme_color)
+  else
+    return nil
+  end
 end
 
 local function set_virtual_text(value)
-	vim.diagnostic.config({
-		virtual_text = value,
-	})
+  vim.diagnostic.config({
+    virtual_text = value,
+  })
 end
 
 return {
-	get_default_diagnostic_colors = get_default_diagnostic_colors,
-	get_default_theme_bg_color = get_default_theme_bg_color,
-	set_virtual_text = set_virtual_text,
+  get_default_diagnostic_colors = get_default_diagnostic_colors,
+  get_default_theme_bg_color = get_default_theme_bg_color,
+  set_virtual_text = set_virtual_text,
 }
+


### PR DESCRIPTION
### Pull Request Body
This pull request adds a safeguard to the set_highlight function in error-lens.nvim to prevent errors when attempting to highlight diagnostics that reference lines outside the valid range of the buffer.

## Problem
Previously, error-lens.nvim could encounter an error (Invalid 'line': out of range) when calling nvim_buf_set_extmark or nvim_buf_add_highlight if a diagnostic line number was out of range. This would disrupt the highlighting and could lead to plugin errors, especially when diagnostics are provided asynchronously or if a buffer is changed dynamically.

## Solution
This fix adds a check to ensure diagnostic.lnum is within the buffer’s line count before attempting to highlight it. Specifically:

The function now verifies that diagnostic.lnum is between 0 and the total number of lines in the buffer.
If diagnostic.lnum is out of range, the function skips highlighting for that diagnostic, thus preventing the error.